### PR TITLE
Language selector added zh-tw

### DIFF
--- a/code_igniter/application/views/theme-bootstrap/v_ldap_servers_create_form.php
+++ b/code_igniter/application/views/theme-bootstrap/v_ldap_servers_create_form.php
@@ -175,6 +175,7 @@
                                 <option value='es'><?php echo __('Spanish'); ?></option>
                                 <option value='fr'><?php echo __('French'); ?></option>
                                 <option value='pt-br'><?php echo __('Brazilian Portuguese'); ?></option>
+                                <option value='zh-tw'><?php echo __('Traditional Chinese'); ?></option>
                             </select>
                         </div>
                     </div>

--- a/code_igniter/application/views/theme-bootstrap/v_ldap_servers_read.php
+++ b/code_igniter/application/views/theme-bootstrap/v_ldap_servers_read.php
@@ -251,6 +251,7 @@ $item = $this->response->data[0];
                                 <option value='es' <?php if ($item->attributes->lang == 'es') { echo "selected"; }?>><?php echo __('Spanish'); ?></option>
                                 <option value='fr' <?php if ($item->attributes->lang == 'fr') { echo "selected"; }?>><?php echo __('French'); ?></option>
                                 <option value='pt-br' <?php if ($item->attributes->lang == 'pt-br') { echo "selected"; }?>><?php echo __('Brazilian Portuguese'); ?></option>
+                                <option value='zh-tw' <?php if ($item->attributes->lang == 'zh-tw') { echo "selected"; }?>><?php echo __('Traditional Chinese'); ?></option>
                             </select>
                             <span class="input-group-btn">
                                 <button id="edit_lang" data-action="edit" class="btn btn-default edit_button" type="button" data-attribute="lang"><span class="glyphicon glyphicon-edit" aria-hidden="true"></span></button>

--- a/code_igniter/application/views/theme-bootstrap/v_users_create_form.php
+++ b/code_igniter/application/views/theme-bootstrap/v_users_create_form.php
@@ -105,6 +105,7 @@
                                 <option value='es'><?php echo __('Spanish'); ?></option>
                                 <option value='fr'><?php echo __('French'); ?></option>
                                 <option value='pt-br'><?php echo __('Brazilian Portuguese'); ?></option>
+                                <option value='zh-tw'><?php echo __('Traditional Chinese'); ?></option>
                             </select>
                         </div>
                     </div>

--- a/code_igniter/application/views/theme-bootstrap/v_users_read.php
+++ b/code_igniter/application/views/theme-bootstrap/v_users_read.php
@@ -125,6 +125,7 @@ $item = $this->response->data[0];
                             <option value='es' <?php if ($item->attributes->lang == 'es') { echo 'selected'; } ?>><?php echo __('Spanish'); ?></option>
                             <option value='fr' <?php if ($item->attributes->lang == 'fr') { echo 'selected'; } ?>><?php echo __('French'); ?></option>
                             <option value='pt-br' <?php if ($item->attributes->lang == 'pt-br') { echo 'selected'; } ?>><?php echo __('Brazilian Portuguese'); ?></option>
+                            <option value='zh-tw' <?php if ($item->attributes->lang == 'zh-tw') { echo 'selected'; } ?>><?php echo __('Traditional Chinese'); ?></option>
                         </select>
                         <?php if (!empty($edit)) { ?>
                         <span class="input-group-btn">


### PR DESCRIPTION
Enable the language selector UI to support traditional Chinese display and selection.

Notes:
Enumeration in "user" field "lang" is not yet zh-tw, please help to add zh-tw to db schema upgrade php file `enum('cs','de','en','es','fr','pt-br','zh-tw')`, thank you!