### PR TITLE
Fixed the problem that some CSS/JS files cannot be loaded in HTTPS.

### DIFF
--- a/code_igniter/application/config/config.php
+++ b/code_igniter/application/config/config.php
@@ -24,7 +24,17 @@ $config['microtime'] = microtime(true);
 // $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']),"",$_SERVER['SCRIPT_NAME']);
 
 if (isset($_SERVER['HTTP_HOST'])) {
-    $config['base_url'] = isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ? 'https' : 'http';
+	// 
+	$is_secure = false;
+	if( isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ) {
+		$is_secure = true;
+	} elseif (!empty($_SERVER['HTTPS_X_FORWARDED_PROTO']) && $_SERVER['HTTPS_X_FORWARDED_PROTO'] === 'https') {
+		$is_secure = true;	
+	} elseif (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] === 'on') {
+		$is_secure = true;
+	}
+	$config['base_url'] = $is_secure ? 'https' : 'http';
+    // $config['base_url'] = isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on' ? 'https' : 'http';
     $config['base_url'] .= '://'.$_SERVER['HTTP_HOST'];
     // $config['base_url'] .= isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] != '80' ? ( ':'.$_SERVER['SERVER_PORT'] ) : '';
     $config['base_url'] .= str_replace(basename($_SERVER['SCRIPT_NAME']), '', $_SERVER['SCRIPT_NAME']);


### PR DESCRIPTION
When using SSL on Nginx reverse proxy or Apache virtual host, the server can't recognize HTTPS connection correctly. This will cause open-audit to generate an incorrect base_url, which leads to a mixed content problem.

This fix makes the server allowed to recognize X-Forwarded-Proto and X-Forwarded-SSL headers and generate a proper base_url. 