### PR TITLE
fix(tasks-model): typo in tasks model string

### DIFF
--- a/app/Models/TasksModel.php
+++ b/app/Models/TasksModel.php
@@ -407,7 +407,7 @@ class TasksModel extends BaseModel
         $dictionary->columns->expire_minutes = 'Unused.';
         $dictionary->columns->first_run = 'The timestamp after which, this task should run. For example, run a task after the 1st June 2017 at 10am, set it to <code>2017-06-01 09:59:00</code>. This value should be zero padded (ie, 09, not 9). This value defaults to <code>2000-01-01 00:00:00</code> which means by default, a scheduled task will run at next scheduled execution time.';
         $dictionary->columns->last_run = 'The last date and time this item was executed (read only).';
-        $dictionary->columns->email_address = 'The email address of the reciever';
+        $dictionary->columns->email_address = 'The email address of the receiver';
         $dictionary->columns->format = 'The format used for the output to be emailed.';
         $dictionary->columns->group_id = 'The Group used to run the Baseline. Links to <code>groups.id</code>.';
         $dictionary->columns->edited_by = $instance->dictionary->edited_by;

--- a/app/Views/lang/ar.php
+++ b/app/Views/lang/ar.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'الرابط المباشر للنص هو';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'عنوان البريد الإلكتروني للمحقق';
+$GLOBALS["lang"]['The email address of the receiver'] = 'عنوان البريد الإلكتروني للمحقق';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'The enterprise binary from FirstWave is required for a license. من فضلك تحميل مفتوح';
 

--- a/app/Views/lang/az.php
+++ b/app/Views/lang/az.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'script üçün birbaşa link';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Reciever e-poçt ünvanı';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Reciever e-poçt ünvanı';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'BirinciWave şirkəti ikilisi lisenziya üçün tələb olunur. Download Open-AudIT';
 

--- a/app/Views/lang/bg.php
+++ b/app/Views/lang/bg.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Директната връзка за скрипта е';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Имейл адресът на ресивера';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Имейл адресът на ресивера';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Двоичното предприятие от FirstWave се изисква за лиценз. Моля, изтеглете Open- AudIT от';
 

--- a/app/Views/lang/cs.php
+++ b/app/Views/lang/cs.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Přímý odkaz pro skript je';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'E-mailová adresa příjemce';
+$GLOBALS["lang"]['The email address of the receiver'] = 'E-mailová adresa příjemce';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Pro licenci je vyžadována podniková binárka z FirstWave. Stáhněte si prosím Open- Audit z';
 

--- a/app/Views/lang/da.php
+++ b/app/Views/lang/da.php
@@ -7019,7 +7019,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Det direkte link til scriptet er';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'E-mailadressen';
+$GLOBALS["lang"]['The email address of the receiver'] = 'E-mailadressen';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Virksomheden binær fra FirstWave er påkrævet for en licens. Download venligst Open- Audit fra';
 

--- a/app/Views/lang/de.php
+++ b/app/Views/lang/de.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Der direkte Link zum Skript ist';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Die E-Mail-Adresse des Revers';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Die E-Mail-Adresse des Revers';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Das Unternehmen binär von FirstWave ist für eine Lizenz erforderlich. Bitte herunterladen Open-AudIT von';
 

--- a/app/Views/lang/dq.php
+++ b/app/Views/lang/dq.php
@@ -7029,7 +7029,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'The direct link for the script is';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'The email address of the reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'The email address of the receiver';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from';
 

--- a/app/Views/lang/el.php
+++ b/app/Views/lang/el.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Ο άμεσος σύνδεσμος για το σενάριο είναι';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Η διεύθυνση ηλεκτρονικού ταχυδρομείου του ανταποκριτή';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Η διεύθυνση ηλεκτρονικού ταχυδρομείου του ανταποκριτή';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Το δυαδικό της επιχείρησης από το FirstWave απαιτείται για μια άδεια. Παρακαλώ κατεβάστε το Open-AudIT από';
 

--- a/app/Views/lang/eo.php
+++ b/app/Views/lang/eo.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'La rekta ligo por la manuskripto estas';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'La retpoŝta adreso de la reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'La retpoŝta adreso de la reciever';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'La entrepreno binara de FirstWave estas postulata por licenco. Bonvolu elŝuti Open-AudIT de';
 

--- a/app/Views/lang/es.php
+++ b/app/Views/lang/es.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'El enlace directo para el script es';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'La dirección de correo electrónico del reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'La dirección de correo electrónico del reciever';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'La empresa binaria de FirstWave es necesaria para una licencia. Por favor, descargar Open-AudIT desde';
 

--- a/app/Views/lang/et.php
+++ b/app/Views/lang/et.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Skripti otselink on';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Retsipiendi e- posti aadress';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Retsipiendi e- posti aadress';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Litsentsi saamiseks on vaja FirstWave\'i ettevõtte binaarset versiooni. Palun lae OpenAudIT alla';
 

--- a/app/Views/lang/fi.php
+++ b/app/Views/lang/fi.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Skriptin suora linkki on';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Vastaanottajan sähköpostiosoite';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Vastaanottajan sähköpostiosoite';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Yrityksen binary FirstWave vaaditaan lisenssi. Lataa Open-AudIT';
 

--- a/app/Views/lang/fr.php
+++ b/app/Views/lang/fr.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Le lien direct pour le script est';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Ladresse e-mail du destinataire';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Ladresse e-mail du destinataire';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Le binaire dentreprise de FirstWave est requis pour une licence. Veuillez télécharger Open-Audit depuis';
 

--- a/app/Views/lang/ga.php
+++ b/app/Views/lang/ga.php
@@ -7019,7 +7019,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Is é an nasc díreach don script';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Seoladh ríomhphoist an reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Seoladh ríomhphoist an reciever';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Tá an dénártha fiontraíochta ó FirstWave ag teastáil le haghaidh ceadúnas. Íoslódáil Open-AudIT ó';
 

--- a/app/Views/lang/hi.php
+++ b/app/Views/lang/hi.php
@@ -7019,7 +7019,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'स्क्रिप्ट के लिए सीधा लिंक है';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'पारस्परिक का ईमेल पता';
+$GLOBALS["lang"]['The email address of the receiver'] = 'पारस्परिक का ईमेल पता';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'फर्स्टवेव से उद्यम द्विआधारी लाइसेंस के लिए आवश्यक है। कृपया Open-Audit को डाउनलोड करें';
 

--- a/app/Views/lang/hu.php
+++ b/app/Views/lang/hu.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'A szkript közvetlen linkje:';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'A kedvezményezett e-mail címe';
+$GLOBALS["lang"]['The email address of the receiver'] = 'A kedvezményezett e-mail címe';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'A vállalat bináris FirstWave szükséges a licenc. Kérjük, töltse le az Open- AudIT programot';
 

--- a/app/Views/lang/id.php
+++ b/app/Views/lang/id.php
@@ -7019,7 +7019,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Tautan langsung untuk skrip adalah';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Alamat surel dari penerima';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Alamat surel dari penerima';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Biner perusahaan dari FirstWave diperlukan untuk lisensi. Silakan unduh Open-Audit dari';
 

--- a/app/Views/lang/it.php
+++ b/app/Views/lang/it.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Il link diretto per lo script è';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'L\'indirizzo email del reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'L\'indirizzo email del reciever';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Il binario di impresa da FirstWave è richiesto per una licenza. Scarica Open-AudIT da';
 

--- a/app/Views/lang/ja.php
+++ b/app/Views/lang/ja.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'スクリプトの直接リンクは';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'レシーバーのメールアドレス';
+$GLOBALS["lang"]['The email address of the receiver'] = 'レシーバーのメールアドレス';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'FirstWave のエンタープライズバイナリはライセンスが必要です。 Open-AudITのダウンロードはこちらから';
 

--- a/app/Views/lang/ko.php
+++ b/app/Views/lang/ko.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = '스크립트에 대한 직접 링크는';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'reciever의 이메일 주소';
+$GLOBALS["lang"]['The email address of the receiver'] = 'reciever의 이메일 주소';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'FirstWave의 엔터프라이즈 바이너리는 라이센스에 필요합니다. Open-AudIT 다운로드';
 

--- a/app/Views/lang/lt.php
+++ b/app/Views/lang/lt.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Tiesioginė nuoroda scenarijų yra';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Gavėjo e. pašto adresas';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Gavėjo e. pašto adresas';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Įmonė dvejetainė iš FirstWave yra reikalinga licencijos. Atsisiųskite Open- AudIT iš';
 

--- a/app/Views/lang/lv.php
+++ b/app/Views/lang/lv.php
@@ -7019,7 +7019,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Tieša skripta saite ir';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Saņēmēja e-pasta adrese';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Saņēmēja e-pasta adrese';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'FirstWave binārais uzņēmums ir nepieciešams licencei. Lūdzu, lejupielādējiet Open- AudIT no';
 

--- a/app/Views/lang/nl.php
+++ b/app/Views/lang/nl.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'De directe link voor het script is';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Het e-mailadres van de reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Het e-mailadres van de reciever';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'De enterprise binary van FirstWave is vereist voor een licentie. Download Open-AudIT van';
 

--- a/app/Views/lang/pb.php
+++ b/app/Views/lang/pb.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'O link direto para o roteiro é';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'O endereço de e-mail do recepcionista.';
+$GLOBALS["lang"]['The email address of the receiver'] = 'O endereço de e-mail do recepcionista.';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'A empresa binária da FirstWave é necessária para uma licença. Por favor, baixe Open-AudIT de';
 

--- a/app/Views/lang/pl.php
+++ b/app/Views/lang/pl.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Bezpośredni link do skryptu jest';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Adres e-mail odbiorcy';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Adres e-mail odbiorcy';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Firma binarna z FirstWave jest wymagana do licencji. Proszę pobrać Open- Audit z';
 

--- a/app/Views/lang/ru.php
+++ b/app/Views/lang/ru.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Прямая ссылка на сценарий — это';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Адрес электронной почты рецивера';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Адрес электронной почты рецивера';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Бинарный бизнес от FirstWave требуется для получения лицензии. Скачать Open-AudIT из';
 

--- a/app/Views/lang/sq.php
+++ b/app/Views/lang/sq.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Lidhja direkte për script-in është';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Adresa email e reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Adresa email e reciever';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Gjurma e ndërmarrjes nga FirstWave kërkohet për një liçensë. Ju lutem shkarkoni Open-AudIT nga';
 

--- a/app/Views/lang/tr.php
+++ b/app/Views/lang/tr.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Senaryo için doğrudan bağlantı,';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Reciever\'in e-posta adresi';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Reciever\'in e-posta adresi';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'İlkWave\'den gelen kurumsal ikili bir lisans için gereklidir. Lütfen Open-AudIT\'ı indirin';
 

--- a/app/Views/lang/uk.php
+++ b/app/Views/lang/uk.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = 'Прямий посилання на скрипт';
 
-$GLOBALS["lang"]['The email address of the reciever'] = 'Адреса електронної пошти reciever';
+$GLOBALS["lang"]['The email address of the receiver'] = 'Адреса електронної пошти reciever';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = 'Підприємець з FirstWave необхідний для ліцензії. Завантажити Open-AudIT';
 

--- a/app/Views/lang/zh.php
+++ b/app/Views/lang/zh.php
@@ -7017,7 +7017,7 @@ $GLOBALS["lang"]['The device within Open-AudIT. Links to <code>devices.id</code>
 
 $GLOBALS["lang"]['The direct link for the script is'] = '脚本的直接链接是';
 
-$GLOBALS["lang"]['The email address of the reciever'] = '回信器的电子邮件地址';
+$GLOBALS["lang"]['The email address of the receiver'] = '回信器的电子邮件地址';
 
 $GLOBALS["lang"]['The enterprise binary from FirstWave is required for a license. Please download Open-AudIT from'] = '来自FirstWave的企业二进制必须持有许可证。 请从 Open-AudIT 下载';
 


### PR DESCRIPTION
Fixes an easily made mistake of spelling receiver with an I after the C instead of the E. Changes the string in TasksModel.php and then updates the localisation keys for all languages referencing it.