### PR TITLE
fix(components-model): correct operator precedence in netstat port check

### DIFF
--- a/app/Models/ComponentsModel.php
+++ b/app/Models/ComponentsModel.php
@@ -1560,7 +1560,7 @@ class ComponentsModel extends BaseModel
                 if (!empty($instance->config->create_change_log_netstat_well_known) and $instance->config->create_change_log_netstat_well_known === 'n' and isset($db_item->port) and intval($db_item->port) < 1024) {
                     $special = false;
                 }
-                if (!empty($instance->config->create_change_log_netstat_registered) and $instance->config->create_change_log_netstat_registered === 'n' and isset($db_item->port) and intval($db_item->port) > 1023 and intval($db_item->port < 49152)) {
+                if (!empty($instance->config->create_change_log_netstat_registered) and $instance->config->create_change_log_netstat_registered === 'n' and isset($db_item->port) and intval($db_item->port) > 1023 and intval($db_item->port) < 49152) {
                     $special = false;
                 }
                 if (!empty($instance->config->create_change_log_netstat_dynamic) and $instance->config->create_change_log_netstat_dynamic === 'n' and isset($db_item->port) and intval($db_item->port) > 49151) {


### PR DESCRIPTION
Noticed the inconsistent parenthesis pattern while reading through the port filtering logic - line 1563 had the closing parenthesis in the wrong spot, wrapping the comparison inside `intval()` instead of just the port value.

Funny enough, it still worked because PHP's `intval(true)` → `1` and `intval(false)` → `0` happen to be truthy/falsy in the right way. Fixed anyway to match lines 1560 and 1566. This is also why tests wouldn't have caught this cause the boolean logic accidentally produces correct results.