### PR TITLE
Data table refresh

### DIFF
--- a/app/Views/discoveriesRead.php
+++ b/app/Views/discoveriesRead.php
@@ -101,13 +101,13 @@ foreach ($included['discovery_scan_options'] as $item) {
                 <div class="col-8 offset-2" style="background-color: rgba(var(--bs-body-color-rgb), 0.03);">
                     <ul class="nav nav-pills nav-fill" id="myTab" role="tablist">
                         <?= $summary_button ?>
+                        <?= $devices_button ?>
+                        <?= $issues_button ?>
                         <?= $details_button ?>
                         <?= $scan_op_button ?>
                         <?= $match_o_button ?>
                         <?= $logs_button ?>
                         <?= $all_ips_button ?>
-                        <?= $devices_button ?>
-                        <?= $issues_button ?>
                     </ul>
                 </div>
             </div>

--- a/app/Views/discoveriesRead.php
+++ b/app/Views/discoveriesRead.php
@@ -1103,7 +1103,7 @@ foreach ($included['discovery_scan_options'] as $item) {
                 serverSide: true,
                 deferLoading: 0,
                 refreshButton: {
-                    tooltip: 'Reload logs',
+                    tooltip: 'Reload devices',
                     autoRefreshIfEmpty: true,
                     autoRefreshInterval: 10000
                 },

--- a/app/Views/discoveriesRead.php
+++ b/app/Views/discoveriesRead.php
@@ -703,6 +703,11 @@ foreach ($included['discovery_scan_options'] as $item) {
                 },
                 serverSide: true,
                 deferLoading: 0,
+                refreshButton: {
+                    tooltip: 'Reload logs',
+                    autoRefreshIfEmpty: true,
+                    autoRefreshInterval: 5000
+                },
                 ajax: {
                     url: '<?= base_url() ?>index.php/discovery_log?discovery_id=<?= $meta->id ?>&format=json',
                     dataSrc: 'data',

--- a/app/Views/discoveriesRead.php
+++ b/app/Views/discoveriesRead.php
@@ -706,7 +706,7 @@ foreach ($included['discovery_scan_options'] as $item) {
                 refreshButton: {
                     tooltip: 'Reload logs',
                     autoRefreshIfEmpty: true,
-                    autoRefreshInterval: 5000
+                    autoRefreshInterval: 10000
                 },
                 ajax: {
                     url: '<?= base_url() ?>index.php/discovery_log?discovery_id=<?= $meta->id ?>&format=json',
@@ -912,6 +912,11 @@ foreach ($included['discovery_scan_options'] as $item) {
                 },
                 serverSide: true,
                 deferLoading: 0,
+                refreshButton: {
+                    tooltip: 'Reload IPs',
+                    autoRefreshIfEmpty: true,
+                    autoRefreshInterval: 10000
+                },
                 ajax: {
                     url: '<?= base_url() ?>index.php/discovery_log?discovery_id=<?= $meta->id ?>&groupby=discovery_log.ip&format=json',
                     dataSrc: 'data',
@@ -1097,6 +1102,11 @@ foreach ($included['discovery_scan_options'] as $item) {
                 },
                 serverSide: true,
                 deferLoading: 0,
+                refreshButton: {
+                    tooltip: 'Reload logs',
+                    autoRefreshIfEmpty: true,
+                    autoRefreshInterval: 10000
+                },
                 devSort: {},
                 ajax: {
                     url: '<?= base_url() ?>index.php/discovery_log?discovery_id=<?= $meta->id ?>&groupby=discovery_log.device_id&format=json',

--- a/app/Views/shared/header.php
+++ b/app/Views/shared/header.php
@@ -55,6 +55,7 @@ if (!empty($config->servers)) {
         <script {csp-script-nonce} defer src="<?= base_url('js/popper.min.js') ?>"></script>
         <script {csp-script-nonce} defer src="<?= base_url('js/bootstrap.bundle.min.js') ?>"></script>
         <script {csp-script-nonce} defer src="<?= base_url('js/datatables.min.js') ?>"></script>
+        <script {csp-script-nonce} defer src="<?= base_url('js/datatables.extra.js') ?>"></script>
         <script {csp-script-nonce} defer src="<?= base_url('js/apexcharts.js') ?>"></script>
         <script {csp-script-nonce} defer src="<?= base_url('js/select2.full.min.js') ?>"></script>
         <script {csp-script-nonce} defer src="<?= base_url('js/open-audit.js') ?>"></script>
@@ -63,6 +64,7 @@ if (!empty($config->servers)) {
         <link href="<?= base_url('css/inter.css') ?>" rel="stylesheet">
         <link href="<?= base_url('css/bootstrap.css') ?>" rel="stylesheet">
         <link href="<?= base_url('css/datatables.min.css') ?>" rel="stylesheet">
+        <link href="<?= base_url('css/datatables.extra.css') ?>" rel="stylesheet">
         <link href="<?= base_url('css/select2.min.css') ?>" rel="stylesheet">
         <link href="<?= base_url('css/select2-bootstrap-5-theme.min.css') ?>" rel="stylesheet">
         <link href="<?= base_url('css/lucide.css') ?>" rel="stylesheet">

--- a/app/Views/shared/read_functions.php
+++ b/app/Views/shared/read_functions.php
@@ -218,6 +218,26 @@ function read_field_header(string $collection = '', string $name = '', string $d
     $label = str_replace('Options.widgets.position.', 'Widget #', $label);
     $label = str_replace('[]', '', $label);
 
+    if (in_array($collection, ['discovery_scan_options', 'discoveries'])) {
+        $name = str_replace('scan_options.', '', $name);
+        $label = match ($name) {
+            'ping'              => __('Must Respond to Ping'),
+            'service_version'   => __('Use Service Version Detection'),
+            'open|filtered'     => __('Consider Open|Filtered Ports Open'),
+            'filtered'          => __('Consider Filtered Ports Open'),
+            'timing'            => __('Timing'),
+            'nmap_tcp_ports'    => __('Top TCP Ports'),
+            'nmap_udp_ports'    => __('Top UDP Ports'),
+            'tcp_ports'         => __('Custom TCP Ports'),
+            'udp_ports'         => __('Custom UDP Ports'),
+            'timeout'           => __('Nmap Timeout Per Target'),
+            'exclude_tcp_ports' => __('Exclude TCP Ports'),
+            'exclude_udp_ports' => __('Exclude UDP Ports'),
+            'exclude_ip'        => __('Exclude IP Addresses'),
+            'ssh_ports'         => __('SSH Running on Ports'),
+            default => $label,
+        };
+    }
 
     $field = (!empty($collection) and !empty($name)) ? '<code>' . $collection . '.' . str_replace('[]', '', $name) . '</code><br>' : '';
     $header = '

--- a/public/css/datatables.extra.css
+++ b/public/css/datatables.extra.css
@@ -1,0 +1,30 @@
+@keyframes dt-refresh-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.dt-refresh-spin {
+    animation: dt-refresh-spin 1s linear infinite;
+}
+
+.dt-refresh button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.dt-refresh button > i {
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+    transform-origin: center center;
+    vertical-align: middle;
+}
+
+.dt-refresh button > span:empty {
+    display: none;
+}
+
+.dt-refresh button > span:not(:empty) {
+    margin-left: 6px;
+}

--- a/public/js/datatables.extra.js
+++ b/public/js/datatables.extra.js
@@ -1,0 +1,105 @@
+(function ($) {
+
+    // Override the default layout, shouldn't change the look but will
+    // allow the refresh button to be injected, when enabled
+    $.extend(true, $.fn.dataTable.defaults, {
+        dom: '<"d-flex justify-content-between"<"dt-left"l><"dt-right d-flex align-items-center gap-2"fR>>tip'
+    });
+
+    const defaults = {
+        className: 'btn btn-light btn-sm',
+        iconClass: 'icon-refresh-cw text-oa-primary',
+        text: "Refresh",
+        tooltip: 'Refresh table data',
+        spinClass: 'dt-refresh-spin',
+        autoDisable: true,
+        resetPaging: true,
+        autoRefreshIfEmpty: false,
+        autoRefreshInterval: 5000
+    };
+
+    $.fn.dataTable.ext.feature.push({
+        cFeature: 'R',
+        fnInit: function (settings) {
+            const optsFromInit = settings.oInit.refreshButton;
+            if (! optsFromInit) {
+                return null;
+            }
+            var api = new $.fn.dataTable.Api(settings);
+            var opts = $.extend(
+                {},
+                defaults,
+                settings.oInit.refreshButton || {}
+            );
+
+            var container = $('<div class="dt-refresh me-2"></div>');
+            var button = $(`
+                <button role="button" class="${opts.className}" title="${opts.tooltip}">
+                    <i class="${opts.iconClass}"></i><span>${opts.text}</span>
+                </button>
+            `);
+
+            var icon = button.find('i');
+            var pollTimer = null;
+
+            function startPolling() {
+                if (!pollTimer) {
+                    pollTimer = setInterval(() => {
+                        if (api.data().count() === 0) {
+                            icon.addClass(opts.spinClass);
+                            if (opts.autoDisable) {
+                                button.prop('disabled', true);
+                            }
+                            api.ajax.reload(null, opts.resetPaging);
+                        } else {
+                            stopPolling();
+                        }
+                    }, opts.autoRefreshInterval);
+                }
+            }
+
+            function stopPolling() {
+                if (pollTimer) {
+                    clearInterval(pollTimer);
+                    pollTimer = null;
+                    icon.removeClass(opts.spinClass);
+                    if (opts.autoDisable) {
+                        button.prop('disabled', false);
+                    }
+                }
+            }
+
+            button.on('click', function () {
+                if (opts.autoDisable) {
+                    button.prop('disabled', true);
+                }
+
+                icon.addClass(opts.spinClass);
+                api.ajax.reload(null, opts.resetPaging);
+            });
+
+            api.on('processing.dt', function (e, settings, processing) {
+                if (!processing) {
+                    icon.removeClass(opts.spinClass);
+                    if (opts.autoDisable) {
+                        button.prop('disabled', false);
+                    }
+
+                    if (opts.autoRefreshIfEmpty && api.data().count() === 0) {
+                        startPolling();
+                    } else {
+                        stopPolling();
+                    }
+                }
+            });
+
+            if (opts.autoRefreshIfEmpty && api.data().count() === 0) {
+                startPolling();
+            }
+
+            container.append(button);
+
+            return container[0];
+        }
+    });
+})(jQuery);


### PR DESCRIPTION
Ticket  `OMK-12348` originally wanted:

* When we view a discovery, we automatically request logs, devices and IPs.
* If any of these respond with 0 data entries, wait 5 seconds, then request that item again.
* We should throw up an indication we are doing that. Maybe dataTables already does.

Seems like something to be requested again, or would be beneficial on other pages and tables. Rather than repeat the same logic in templates over and over again, this has been bundled into an extension.

**Usage**:

```js
var logTable = new DataTable('.dataTableLog', {
    refreshButton: {
        tooltip: 'Reload logs',
        autoRefreshIfEmpty: true,
        autoRefreshInterval: 5000
    },
};
```

Available options:

```js
{
    className: 'btn btn-light btn-sm',
    iconClass: 'icon-refresh-cw text-oa-primary',
    text: "Refresh",
    tooltip: 'Refresh table data',
    spinClass: 'dt-refresh-spin',
    autoDisable: true,
    resetPaging: true,
    autoRefreshIfEmpty: false,
    autoRefreshInterval: 5000
}
```

<img width="3688" height="1763" alt="image" src="https://github.com/user-attachments/assets/d1229ada-e440-4ee6-90d8-b3d3a1164cd5" />

---

**Closes**:
* [OMK-12348](https://firstwavecloud.atlassian.net/browse/OMK-12348)
* [OMK-12351](https://firstwavecloud.atlassian.net/browse/OMK-12351)
* [OMK-12390](https://firstwavecloud.atlassian.net/browse/OMK-12390)
