### PR TITLE
Improvements to polling and refreshing table data

### DIFF
--- a/app/Views/discoveriesRead.php
+++ b/app/Views/discoveriesRead.php
@@ -696,6 +696,58 @@ foreach ($included['discovery_scan_options'] as $item) {
                 }
             });
 
+            // Discovery interval, cleared once no longer running
+            var discoveryInterval = null;
+            // Whether tables should refresh data periodically
+            var refreshTableData = true;
+            // Interval to check whether a discovery is running
+            var checkDiscoveryInterval = 8000;
+            // Interval to refresh table data
+            var refreshTableDataInterval = 10000;
+
+            function checkDiscoveryStatus() {
+                $.ajax({
+                    url: '/index.php/discoveries/1?format=json',
+                    method: 'GET',
+                    dataType: 'json',
+                    success: function (response) {
+                        if (response.data && response.data.length) {
+                            var item = response.data[0];
+                            var attributes = item.attributes || {};
+
+                            if (! attributes.last_run || ! attributes.last_finished) {
+                                return false;
+                            }
+
+                            var lastRun = new Date(attributes.last_run);
+                            var lastFinished = new Date(attributes.last_finished);
+                            // Unsure whether this is adequate, but we do not track PID's or a
+                            // dedicated field determining whether the discovery is running
+                            if (lastRun.getTime() <= lastFinished.getTime()) {
+                                refreshTableData = false;
+                                clearInterval(discoveryInterval);
+                                discoveryInterval = null;
+                            } else {
+                                refreshTableData = true;
+                            }
+                        }
+                    },
+                    error: function () {
+                        return false;
+                    }
+                });
+            }
+
+            function startDiscoveryStatusPolling() {
+                if (discoveryInterval) return;
+                checkDiscoveryStatus();
+                discoveryInterval = setInterval(() => {
+                    checkDiscoveryStatus();
+                }, checkDiscoveryInterval);
+            }
+
+            startDiscoveryStatusPolling();
+
             let logSort = {};
             var myDataTableLog = new DataTable('.dataTableLog', {
                 lengthChange: true,
@@ -869,7 +921,10 @@ foreach ($included['discovery_scan_options'] as $item) {
                                 extend: 'refresh',
                                 boundToTab: '#logs-tab',
                                 autoRefreshIfEmpty: true,
-                                autoRefreshInterval: 10000
+                                autoRefreshInterval: refreshTableDataInterval,
+                                continueRefreshing: function () {
+                                    return refreshTableData;
+                                }
                             }
                         ]
                     },
@@ -1062,7 +1117,10 @@ foreach ($included['discovery_scan_options'] as $item) {
                                 extend: 'refresh',
                                 boundToTab: '#all_ips-tab',
                                 autoRefreshIfEmpty: true,
-                                autoRefreshInterval: 10000
+                                autoRefreshInterval: refreshTableDataInterval,
+                                continueRefreshing: function () {
+                                    return refreshTableData;
+                                }
                             }
                         ]
                     },
@@ -1256,7 +1314,10 @@ foreach ($included['discovery_scan_options'] as $item) {
                                 extend: 'refresh',
                                 boundToTab: '#devices-tab',
                                 autoRefreshIfEmpty: true,
-                                autoRefreshInterval: 10000
+                                autoRefreshInterval: refreshTableDataInterval,
+                                continueRefreshing: function () {
+                                    return refreshTableData;
+                                }
                             }
                         ]
                     },

--- a/public/js/datatables.extra.js
+++ b/public/js/datatables.extra.js
@@ -2,14 +2,15 @@
 
     var defaults = {
         text: '<i class="icon-refresh-cw text-oa-primary"></i> Refresh',
-        className: 'btn btn-light btn-sm',
+        className: 'btn btn-sm',
         spinClass: 'dt-refresh-spin',
         autoDisable: true,
         resetPaging: true,
         boundToTab: null,
         tabActiveClass: 'active',
         autoRefreshIfEmpty: false,
-        autoRefreshInterval: 5000
+        autoRefreshInterval: 5000,
+        continueRefreshing: null
     };
 
     $.fn.dataTable.ext.buttons.refresh = function (table, config) {
@@ -36,6 +37,14 @@
         function startPolling() {
             if (!pollTimer) {
                 pollTimer = setInterval(() => {
+                    if (typeof options.continueRefreshing === 'function') {
+                        var continuePolling = options.continueRefreshing();
+                        if (! continuePolling) {
+                            stopPolling();
+                            return;
+                        }
+                    }
+
                     if (table.data().count() === 0) {
                         if (options.boundToTab) {
                             var tab = $(options.boundToTab);


### PR DESCRIPTION
A quick breakdown on what's now occurring on the discovery page.

1. Page loads
2. Initiate polling the discoveries API to determine whether the current discovery is running.
3. Each table specifies a callback `continueRefreshing` returning whether the discovery is running.
4. Each table checks whether `continueRefreshing` returns `true` before attempting to refresh data.

**Closes**:
* [OMK-12429](https://firstwavecloud.atlassian.net/browse/OMK-12429)